### PR TITLE
feat: Cloudinary를 이용한 클라우드 이미지 저장 기능 통합

### DIFF
--- a/backend/Services/StyleService.js
+++ b/backend/Services/StyleService.js
@@ -2,16 +2,27 @@ import { PrismaClient } from '@prisma/client';
 import imageToImageUrls from '../Utils/ImageToImageUrls.js';
 import getRanking from '../Utils/CalculateRanking.js';
 import { verifyPassword } from '../Utils/VerifyPassword.js';
-import { imageUpload } from '../Utils/imageUpload.js';
+//import { imageUpload } from '../Utils/imageUpload.js';
+import { v2 as cloudinary } from 'cloudinary';
+import fs from 'fs';
+
+cloudinary.config({
+  cloud_name: process.env.CLOUDINARY_CLOUD_NAME,
+  api_key: process.env.CLOUDINARY_API_KEY,
+  api_secret: process.env.CLOUDINARY_API_SECRET,
+});
 
 const prisma = new PrismaClient();
 
 function postImage() {
-  return (req, res) => {
+  return async (req, res) => {
     try {
-      const { mimetype, filename, path } = req.file;
-      const uploadedPath = imageUpload(mimetype, filename, path);
-      res.status(201).json({ imageUrl: 'http://localhost:3001/' + uploadedPath }); // prettier-ignore
+      const { path } = req.file;
+      const result = await cloudinary.uploader.upload(path, {
+        folder: 'team7_images',
+      });
+      fs.unlinkSync(path);
+      res.status(201).json({ imageUrl: result.secure_url }); // prettier-ignore
     } catch (e) {
       res.status(500).json({ error: 'server error!' });
     }

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@prisma/client": "^6.13.0",
         "bcrypt": "^6.0.0",
+        "cloudinary": "^2.7.0",
         "cors": "^2.8.5",
         "dotenv": "^17.2.1",
         "express": "^5.1.0",
@@ -323,6 +324,19 @@
       "license": "MIT",
       "dependencies": {
         "consola": "^3.2.3"
+      }
+    },
+    "node_modules/cloudinary": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/cloudinary/-/cloudinary-2.7.0.tgz",
+      "integrity": "sha512-qrqDn31+qkMCzKu1GfRpzPNAO86jchcNwEHCUiqvPHNSFqu7FTNF9FuAkBUyvM1CFFgFPu64NT0DyeREwLwK0w==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "q": "^1.5.1"
+      },
+      "engines": {
+        "node": ">=9"
       }
     },
     "node_modules/concat-stream": {
@@ -863,6 +877,12 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
@@ -1308,6 +1328,17 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/q": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+      "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==",
+      "deprecated": "You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.\n\n(For a CapTP with native promises, see @endo/eventual-send and @endo/captp)",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.0",
+        "teleport": ">=0.2.0"
+      }
     },
     "node_modules/qs": {
       "version": "6.14.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@prisma/client": "^6.13.0",
     "bcrypt": "^6.0.0",
+    "cloudinary": "^2.7.0",
     "cors": "^2.8.5",
     "dotenv": "^17.2.1",
     "express": "^5.1.0",

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,23 +1,28 @@
 /** @type {import('next').NextConfig} */
-const path = require('path')
+const path = require("path");
 
 module.exports = {
   reactStrictMode: true,
   sassOptions: {
-    includePaths: [path.join(__dirname, 'styles')],
+    includePaths: [path.join(__dirname, "styles")],
     prependData: `@use "src/styles/utils.scss" as *;`,
   },
   images: {
     remotePatterns: [
       {
-        protocol: 'http',
-        hostname: 'localhost',
-        port: '3001',
+        protocol: "http",
+        hostname: "localhost",
+        port: "3001",
       },
       {
-        protocol: 'https',
-        hostname: 'sprint-be-project.s3.ap-northeast-2.amazonaws.com',
+        protocol: "https",
+        hostname: "sprint-be-project.s3.ap-northeast-2.amazonaws.com",
+      },
+      {
+        protocol: "https",
+        hostname: "res.cloudinary.com",
+        pathname: "/**/image/upload/**",
       },
     ],
   },
-}
+};


### PR DESCRIPTION
1. cloudinary sdk 추가되어 npm install 한 번 실행해주세요!

2. 각자 로컬에서 cloudinary를 사용하려면 환경변수에 각자의 cloudinary 변수를 저장해줘야 합니다. (배포 때 계정 하나로 정해서 환경변수 설정하기 전까지 로컬에서 각자 테스트하면 될 것 같습니다.) 
```
CLOUDINARY_CLOUD_NAME=~~
CLOUDINARY_API_KEY=~~
CLOUDINARY_API_SECRET=~~
```
기존 로컬 파일 시스템 저장 방식에서 Cloudinary를 주 이미지 저장 스토리지로 통합
 `backend/Services/StyleService.js`의 `postImage` 함수를 수정하여 기존 upload 폴더를 임시 로컬 파일 경로로 사용하고, 이를 cloudinary에 업로드 한 후 임시 로컬 파일을 삭제하도록 구현했습니다.

프론트엔드에서 cloudinary 경로 인식할 수 있도록 next.config.js 부분만 수정했습니다.