### PR TITLE
feat: 큐레이션 관련 에러 수정 및 삭제 성공 알림 개선

### DIFF
--- a/backend/Middlewares/errorHandler.js
+++ b/backend/Middlewares/errorHandler.js
@@ -1,6 +1,8 @@
 export default function errorHandler(err, req, res, next) {
   console.error(err);
-  if (err?.code === 'P2025') {
+  if (err.message && err.message.includes('해당 스타일에 이미 큐레이션을 등록한 사용자입니다.')) {
+    res.status(400).json({ error: '이미 큐레이션을 등록하셨습니다.' });
+  } else if (err?.code === 'P2025') {
     res.status(404).json({ error: 'id를 찾을 수 없습니다.' });
   } else if (err?.name === 'StructError') {
     res.status(400).json({
@@ -10,6 +12,6 @@ export default function errorHandler(err, req, res, next) {
   } else if (err?.statusCode) {
     res.status(err.statusCode).json({ error: err.message });
   } else {
-    res.status(500).json({ error: 'server error' });
+    res.status(500).json({ error: '큐레이션 생성에 실패했습니다.' });
   }
 }

--- a/backend/Middlewares/errorHandler.js
+++ b/backend/Middlewares/errorHandler.js
@@ -12,6 +12,6 @@ export default function errorHandler(err, req, res, next) {
   } else if (err?.statusCode) {
     res.status(err.statusCode).json({ error: err.message });
   } else {
-    res.status(500).json({ error: '큐레이션 생성에 실패했습니다.' });
+    res.status(500).json({ error: err.message });
   }
 }

--- a/frontend/src/libs/curating/feature-curating/CuratingCreateButton.tsx
+++ b/frontend/src/libs/curating/feature-curating/CuratingCreateButton.tsx
@@ -41,9 +41,17 @@ const CuratingCreateButton = ({
       openConfirmModal({
         description: "큐레이팅 등록이 완료되었습니다.",
       });
-    } catch (error) {
+    } catch (error: any) {
+      // Add : any to error to access message property
+      let errorMessage = "큐레이팅 등록에 실패했습니다.";
+      if (
+        error.message &&
+        error.message.includes("이미 큐레이션을 등록하셨습니다.")
+      ) {
+        errorMessage = error.message;
+      }
       openConfirmModal({
-        description: "큐레이팅 등록에 실패했습니다.",
+        description: errorMessage,
       });
     }
   };

--- a/frontend/src/libs/curating/feature-curating/CuratingOptionButtons.tsx
+++ b/frontend/src/libs/curating/feature-curating/CuratingOptionButtons.tsx
@@ -1,58 +1,59 @@
-'use client'
+"use client";
 
-import OptionButtonsLayout from '@libs/shared/layout/OptionButtonsLayout'
-import FormModal from '@libs/shared/modal/form-modal/FormModal'
-import useModal from '@libs/shared/modal/useModal'
-import { CuratingDeleteFormInput, CuratingFormInput, CuratingType } from '@services/types'
-import CuratingForm from './CuratingForm'
-import useConfirmModal from '@libs/shared/modal/useConfirmModal'
-import putCurating from '../data-access-curating/putCurating'
-import deleteCurating from '../data-access-curating/deleteCurating'
-import { useRouter } from 'next/navigation'
-import useUpdateQueryURL from '@libs/shared/util-hook/useUpdateQueryURL'
-import { useAuth } from '@context/AuthContext'
+import OptionButtonsLayout from "@libs/shared/layout/OptionButtonsLayout";
+import FormModal from "@libs/shared/modal/form-modal/FormModal";
+import useModal from "@libs/shared/modal/useModal";
+import {
+  CuratingDeleteFormInput,
+  CuratingFormInput,
+  CuratingType,
+} from "@services/types";
+import CuratingForm from "./CuratingForm";
+import useConfirmModal from "@libs/shared/modal/useConfirmModal";
+import putCurating from "../data-access-curating/putCurating";
+import deleteCurating from "../data-access-curating/deleteCurating";
+import { useRouter } from "next/navigation";
+import useUpdateQueryURL from "@libs/shared/util-hook/useUpdateQueryURL";
+import { useAuth } from "@context/AuthContext";
 
 type CuratingOptionButtonsProps = {
-  curating: CuratingType
-}
+  curating: CuratingType;
+};
 
 const CuratingOptionButtons = ({ curating }: CuratingOptionButtonsProps) => {
-  const curatingEditFormModal = useModal()
-  const curatingDeleteFormModal = useModal()
-  const { renderConfirmModal, openConfirmModal } = useConfirmModal()
+  const curatingEditFormModal = useModal();
+  const curatingDeleteFormModal = useModal();
+  const { renderConfirmModal, openConfirmModal } = useConfirmModal();
 
-  const router = useRouter()
-  const { updateQueryURL } = useUpdateQueryURL()
-  const { user: authUser, isLoggedIn } = useAuth()
+  const router = useRouter();
+  const { updateQueryURL } = useUpdateQueryURL();
+  const { user: authUser, isLoggedIn } = useAuth();
 
   const handleEditCurating = async (data: CuratingFormInput) => {
     try {
-      await putCurating(curating.id, data)
-      curatingEditFormModal.closeModal()
+      await putCurating(curating.id, data);
+      curatingEditFormModal.closeModal();
       openConfirmModal({
-        description: '큐레이팅 수정이 완료되었습니다.',
-      })
+        description: "큐레이팅 수정이 완료되었습니다.",
+      });
     } catch (error) {
       openConfirmModal({
-        description: '큐레이팅 수정에 실패했습니다.',
-      })
+        description: "큐레이팅 수정에 실패했습니다.",
+      });
     }
-  }
+  };
 
   const handleDeleteCurating = async (data: CuratingDeleteFormInput) => {
     try {
-      await deleteCurating(curating.id, data)
-      router.push(updateQueryURL({ page: 1 }), { scroll: false })
-      curatingDeleteFormModal.closeModal()
-      openConfirmModal({
-        description: '큐레이팅 삭제가 완료되었습니다.',
-      })
+      await deleteCurating(curating.id, data);
+      router.push(updateQueryURL({ page: 1 }), { scroll: false });
+      alert("큐레이팅 삭제가 완료되었습니다.");
     } catch (error) {
       openConfirmModal({
-        description: '큐레이팅 삭제에 실패했습니다.',
-      })
+        description: "큐레이팅 삭제에 실패했습니다.",
+      });
     }
-  }
+  };
 
   // If not logged in, or authUser is not yet loaded, don't render buttons
   if (!isLoggedIn || authUser === undefined) {
@@ -68,14 +69,21 @@ const CuratingOptionButtons = ({ curating }: CuratingOptionButtonsProps) => {
   return (
     <>
       <OptionButtonsLayout
-        onClickEdit={() => { curatingEditFormModal.openModal() }}
-        onClickDelete={() => { openConfirmModal({ description: '해당 큐레이션을 삭제하시겠습니까?', onConfirm: () => handleDeleteCurating({}) }) }}
+        onClickEdit={() => {
+          curatingEditFormModal.openModal();
+        }}
+        onClickDelete={() => {
+          openConfirmModal({
+            description: "해당 큐레이션을 삭제하시겠습니까?",
+            onConfirm: () => handleDeleteCurating({}),
+          });
+        }}
       />
       <FormModal
         ref={curatingEditFormModal.modalRef}
         onClose={curatingEditFormModal.closeModal}
-        title='큐레이팅'
-        content={(
+        title="큐레이팅"
+        content={
           <CuratingForm
             onSubmit={handleEditCurating}
             defaultValues={{
@@ -84,15 +92,14 @@ const CuratingOptionButtons = ({ curating }: CuratingOptionButtonsProps) => {
               practicality: curating.practicality,
               costEffectiveness: curating.costEffectiveness,
               content: curating.content,
-              nickname: curating.user.nickname,
             }}
           />
-        )}
+        }
       />
-      
+
       {renderConfirmModal()}
     </>
-  )
-}
+  );
+};
 
-export default CuratingOptionButtons
+export default CuratingOptionButtons;

--- a/frontend/src/libs/curating/ui-curating/CuratingLayout.tsx
+++ b/frontend/src/libs/curating/ui-curating/CuratingLayout.tsx
@@ -15,7 +15,6 @@ type CuratingLayoutProps = {
 
 const CuratingLayout = ({ curating, optionButtons }: CuratingLayoutProps) => {
   const {
-    nickname,
     content,
     trendy,
     personality,
@@ -23,6 +22,7 @@ const CuratingLayout = ({ curating, optionButtons }: CuratingLayoutProps) => {
     costEffectiveness,
     comments,
   } = curating;
+  const nickname = curating.user.nickname;
   const points = [
     { point: trendy, text: "트렌디" },
     { point: personality, text: "개성" },
@@ -35,7 +35,6 @@ const CuratingLayout = ({ curating, optionButtons }: CuratingLayoutProps) => {
       <div className={cx("header")}>
         <h3 className={cx("left")}>
           {nickname}
-          <span className={cx("curator")}>큐레이터</span>
         </h3>
         <div className={cx("right")}>{optionButtons}</div>
       </div>

--- a/frontend/src/services/fetch.ts
+++ b/frontend/src/services/fetch.ts
@@ -47,7 +47,16 @@ const enhancedFetch: (
     }
     if (!response.ok) {
       await logError(response);
-      throw new Error(`HTTP error! status: ${response.status}`);
+      let errorMessage = `HTTP error! status: ${response.status}`;
+      try {
+        const errorData = await response.clone().json();
+        if (errorData && errorData.error) {
+          errorMessage = errorData.error;
+        }
+      } catch (jsonError) {
+        console.error('Failed to parse error response as JSON:', jsonError);
+      }
+      throw new Error(errorMessage);
     }
   } catch (error) {
     console.error(error);


### PR DESCRIPTION
- 큐레이션 등록자 닉네임이 뜨도록 수정
- 큐레이션 삭제 성공 알림 개선
- 큐레이션 등록한 사용자가 중복 등록 불가하도록 에러 핸들링 추가
- enhancedFetch를 수정해서 response.ok가 false일 때 백엔드의 JSON 응답에서 실제 오류 메시지를 추출하도록 수정
- handleCreateCurating의 catch 블록을 수정해서 error.message가 "이미 큐레이션을 등록하셨습니다."이면 해당 메시지를 표시하도록 함. else로 "큐레이팅 등록에 실패했습니다."를 표시

related to: #78 #80