### PR TITLE
feat: 유저 삭제시 관련된 태그 사용량 감소 로직 추가

### DIFF
--- a/backend/Services/StyleService.js
+++ b/backend/Services/StyleService.js
@@ -314,8 +314,12 @@ async function putStyleService({ id }, { imageUrls, Image, tags, ...data }) {
   // 삭제한 태그가 있을 경우 1씩 감소
   if (removedTagIds.length > 0) {
     await prisma.tag.updateMany({
-      where: { id: { in: removedTagIds } },
-      data: { totalUsageCount: { decrement: 1 } },
+      where: {
+        id: { in: removedTagIds },
+      },
+      data: {
+        totalUsageCount: { decrement: 1 },
+      },
     });
   }
 
@@ -412,8 +416,12 @@ async function deleteStyleService({ id }) {
   if (styleToDelete && styleToDelete.tags.length > 0) {
     const tagIdsToDecrement = styleToDelete.tags.map((tag) => tag.id);
     await prisma.tag.updateMany({
-      where: { id: { in: tagIdsToDecrement } },
-      data: { totalUsageCount: { decrement: 1 } },
+      where: {
+        id: { in: tagIdsToDecrement },
+      },
+      data: {
+        totalUsageCount: { decrement: 1 },
+      },
     });
   }
 

--- a/backend/Services/UserService.js
+++ b/backend/Services/UserService.js
@@ -42,9 +42,7 @@ async function requestVerificationService({ email, password, nickname }) {
     throw new Error('이미 가입된 이메일 또는 닉네임입니다.');
   }
 
-  const verificationCode = Math.floor(
-    100000 + Math.random() * 900000,
-  ).toString();
+  const verificationCode = Math.floor(100000 + Math.random() * 900000).toString();
   const userData = JSON.stringify({
     password,
     nickname,
@@ -169,7 +167,8 @@ async function deleteUserService(userId) {
   // 1. 유저랑 연결된 이미지 조회
   // 2. 클라우디너리에서 해당 이미지 삭제
   // 3. db Image 테이블에서 해당 이미지 삭제
-  // 4. 유저 삭제
+  // 4. 유저와 관련된 모든 스타일의 태그사용량 감소
+  // 5. 유저 삭제
   // prettier-ignore
   const result = await prisma.$transaction(async (tx) => { 
     const deleteUser = await tx.user.findUniqueOrThrow({
@@ -185,6 +184,30 @@ async function deleteUserService(userId) {
       // DB에서 기존 Image 레코드 삭제
       await tx.image.delete({ where: { id: deleteUser.imageId } });
     }
+      // 사용자가 작성한 모든 스타일을 찾음
+    const userStyles = await tx.style.findMany({
+      where: { userId: userId },
+      include: { tags: true },
+    });
+    // 모든 스타일에 포함된 태그들의 ID를 수집
+    const tagIds = userStyles.flatMap((style) => style.tags.map((tag) => tag.id));
+
+    // 태그 사용 횟수 감소
+    if (tagIds.length > 0) {
+      await tx.tag.updateMany({
+        where: {
+          id: {
+            in: tagIds,
+          },
+        },
+        data: {
+          totalUsageCount: {
+            decrement: 1,
+          },
+        },
+      });
+    }
+
     const user = await tx.user.delete({ // 유저 삭제
       where: { id: userId },
     });


### PR DESCRIPTION
- 유저 삭제시 관련된 스타일을 검색을 한뒤에 사용한 태그를 찾아 사용량을 감소합니다.
- 유저 삭제 함수에 트랜젝션이 있어서 거기에 포함 시켰습니다.